### PR TITLE
Defer events to the next tick

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,6 +1,7 @@
 {
     "type": "application",
     "source-directories": [
+        ".",
         "src"
     ],
     "elm-version": "0.19.0",

--- a/src/Puzzler.elm
+++ b/src/Puzzler.elm
@@ -88,7 +88,7 @@ handler :
 handler handleAction handleEvent model ( state, maybeEvent ) =
     case maybeEvent of
         Nothing ->
-            model
+            { model | state = state }
 
         Just event ->
             let

--- a/src/puzzles/NoughtsCrosses.elm
+++ b/src/puzzles/NoughtsCrosses.elm
@@ -12,11 +12,6 @@ type Event
     = OpponentMove Int Int
 
 
-type Piece
-    = Nought
-    | Cross
-
-
 type alias Go =
     { us : Bool, coords : ( Int, Int ) }
 
@@ -27,11 +22,19 @@ type alias State =
 
 handleTick : State -> Tick -> ( State, Maybe Event )
 handleTick state tick =
-    if tick == 1 && List.isEmpty state then
-        takeGo state
+    case ( tick, state ) of
+        ( 1, [] ) ->
+            takeGo state
 
-    else
-        ( state, Nothing )
+        ( _, { us, coords } :: _ ) ->
+            if us then
+                ( state, Just <| OpponentMove (Tuple.first coords) (Tuple.second coords) )
+
+            else
+                takeGo state
+
+        _ ->
+            ( state, Nothing )
 
 
 handleAction : State -> Action -> ( State, Maybe Event )
@@ -40,9 +43,10 @@ handleAction state (PlayerMove x y) =
         ( state, Nothing )
 
     else
-        { us = False, coords = ( x, y ) }
+        ( { us = False, coords = ( x, y ) }
             :: state
-            |> takeGo
+        , Nothing
+        )
 
 
 takeGo : State -> ( State, Maybe Event )
@@ -69,7 +73,7 @@ takeGo state =
     in
     case maybeNext of
         Just ( x, y ) ->
-            ( { us = True, coords = ( x, y ) } :: state, Just <| OpponentMove x y )
+            ( { us = True, coords = ( x, y ) } :: state, Nothing )
 
         Nothing ->
             ( state, Nothing )


### PR DESCRIPTION
Playing after the last meetup, I was trying to get time-travelling to work with the example Puzzle and thought those changes could be useful to the main repo. They include:

- In `Puzzler`: Updating the `state` even when no event was triggered so that changes get reflected in the next `Tick`
- In the `NoughsCrosses` puzzle:
  - Deferring opponent's and player's moves to the next tick so that they appear one by one and the unfolding of the puzzle can be time-travelled
  - Removing the unused `Piece` type
- Added the main directory to the sources (Not sure if that's necessary but my IDE wouldn't pickup `Main.elm` without adding it)